### PR TITLE
Fix/env refcount

### DIFF
--- a/lib/src/headless_webview.dart
+++ b/lib/src/headless_webview.dart
@@ -278,7 +278,7 @@ class HeadlessWebview {
       _onSourceLoadedStreamController.close();
     } catch (_) {}
 
-    if (!WebViewInstanceTracker.unregister() && _webviewId.isNotEmpty) {
+    if (!await WebViewInstanceTracker.unregister() && _webviewId.isNotEmpty) {
       await _pluginChannel.invokeMethod('disposeHeadless', _webviewId);
     }
   }

--- a/lib/src/headless_webview.dart
+++ b/lib/src/headless_webview.dart
@@ -278,11 +278,9 @@ class HeadlessWebview {
       _onSourceLoadedStreamController.close();
     } catch (_) {}
 
-    if (_webviewId.isNotEmpty) {
+    if (!WebViewInstanceTracker.unregister() && _webviewId.isNotEmpty) {
       await _pluginChannel.invokeMethod('disposeHeadless', _webviewId);
     }
-
-    WebViewInstanceTracker.unregister();
   }
 
   /// Loads the given [url].

--- a/lib/src/headless_webview.dart
+++ b/lib/src/headless_webview.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:flutter/services.dart';
 
 import 'enums.dart';
+import 'webview_instance_tracker.dart';
 
 typedef HeadlessPermissionRequestedDelegate
     = FutureOr<WebviewPermissionDecision> Function(
@@ -154,6 +155,7 @@ class HeadlessWebview {
         throw MissingPluginException('Unknown method ${call.method}');
       });
 
+      WebViewInstanceTracker.register();
       _value = _value.copyWith(isInitialized: true, isRunning: true);
       _creatingCompleter.complete();
     } on PlatformException catch (e) {
@@ -279,6 +281,8 @@ class HeadlessWebview {
     if (_webviewId.isNotEmpty) {
       await _pluginChannel.invokeMethod('disposeHeadless', _webviewId);
     }
+
+    WebViewInstanceTracker.unregister();
   }
 
   /// Loads the given [url].

--- a/lib/src/webview.dart
+++ b/lib/src/webview.dart
@@ -354,7 +354,7 @@ class WebviewController extends ValueNotifier<WebviewValue> {
         _onSourceLoadedStreamController.close();
       } catch (_) {}
 
-      if (!WebViewInstanceTracker.unregister()) {
+      if (!await WebViewInstanceTracker.unregister()) {
         await _pluginChannel.invokeMethod('dispose', _textureId);
       }
     }

--- a/lib/src/webview.dart
+++ b/lib/src/webview.dart
@@ -354,7 +354,7 @@ class WebviewController extends ValueNotifier<WebviewValue> {
         _onSourceLoadedStreamController.close();
       } catch (_) {}
 
-      if (!WebViewInstanceTracker.unregister() && _textureId != 0) {
+      if (!WebViewInstanceTracker.unregister()) {
         await _pluginChannel.invokeMethod('dispose', _textureId);
       }
     }

--- a/lib/src/webview.dart
+++ b/lib/src/webview.dart
@@ -354,9 +354,9 @@ class WebviewController extends ValueNotifier<WebviewValue> {
         _onSourceLoadedStreamController.close();
       } catch (_) {}
 
-      await _pluginChannel.invokeMethod('dispose', _textureId);
-
-      WebViewInstanceTracker.unregister();
+      if (!WebViewInstanceTracker.unregister() && _textureId != 0) {
+        await _pluginChannel.invokeMethod('dispose', _textureId);
+      }
     }
 
     super.dispose();

--- a/lib/src/webview_instance_tracker.dart
+++ b/lib/src/webview_instance_tracker.dart
@@ -21,13 +21,13 @@ class WebViewInstanceTracker {
   /// Returns `true` if environment was disposed (last instance).
   /// Caller should skip individual dispose when this returns `true`,
   /// as [WebviewController.disposeEnvironment] already handles cleanup.
-  static bool unregister() {
+  static Future<bool> unregister() async {
     if (_activeInstanceCount <= 0) return false;
     _activeInstanceCount--;
     debugPrint('WebViewInstanceTracker: unregister, active instances: $_activeInstanceCount');
     if (_activeInstanceCount == 0) {
       debugPrint('WebViewInstanceTracker: all instances disposed, resetting environment');
-      WebviewController.disposeEnvironment();
+      await WebviewController.disposeEnvironment();
       return true;
     }
     return false;

--- a/lib/src/webview_instance_tracker.dart
+++ b/lib/src/webview_instance_tracker.dart
@@ -18,13 +18,18 @@ class WebViewInstanceTracker {
     debugPrint('WebViewInstanceTracker: register, active instances: $_activeInstanceCount');
   }
 
-  static void unregister() {
-    if (_activeInstanceCount <= 0) return;
+  /// Returns `true` if environment was disposed (last instance).
+  /// Caller should skip individual dispose when this returns `true`,
+  /// as [WebviewController.disposeEnvironment] already handles cleanup.
+  static bool unregister() {
+    if (_activeInstanceCount <= 0) return false;
     _activeInstanceCount--;
     debugPrint('WebViewInstanceTracker: unregister, active instances: $_activeInstanceCount');
     if (_activeInstanceCount == 0) {
       debugPrint('WebViewInstanceTracker: all instances disposed, resetting environment');
       WebviewController.disposeEnvironment();
+      return true;
     }
+    return false;
   }
 }

--- a/lib/src/webview_instance_tracker.dart
+++ b/lib/src/webview_instance_tracker.dart
@@ -1,0 +1,25 @@
+import 'webview.dart';
+
+/// Internal tracker for active WebView instance count.
+///
+/// Both [WebviewController] and [HeadlessWebview] register/unregister
+/// through this class. When the last instance is disposed, the shared
+/// WebView2 environment is automatically destroyed, allowing
+/// re-initialization with new parameters (e.g. proxy settings).
+class WebViewInstanceTracker {
+  WebViewInstanceTracker._();
+
+  static int _activeInstanceCount = 0;
+
+  static void register() {
+    _activeInstanceCount++;
+  }
+
+  static void unregister() {
+    if (_activeInstanceCount <= 0) return;
+    _activeInstanceCount--;
+    if (_activeInstanceCount == 0) {
+      WebviewController.disposeEnvironment();
+    }
+  }
+}

--- a/lib/src/webview_instance_tracker.dart
+++ b/lib/src/webview_instance_tracker.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import 'webview.dart';
 
 /// Internal tracker for active WebView instance count.
@@ -13,12 +15,15 @@ class WebViewInstanceTracker {
 
   static void register() {
     _activeInstanceCount++;
+    debugPrint('WebViewInstanceTracker: register, active instances: $_activeInstanceCount');
   }
 
   static void unregister() {
     if (_activeInstanceCount <= 0) return;
     _activeInstanceCount--;
+    debugPrint('WebViewInstanceTracker: unregister, active instances: $_activeInstanceCount');
     if (_activeInstanceCount == 0) {
+      debugPrint('WebViewInstanceTracker: all instances disposed, resetting environment');
       WebviewController.disposeEnvironment();
     }
   }


### PR DESCRIPTION
  新增 WebViewInstanceTracker — 引用计数管理环境生命周期：
  - register() / unregister() 追踪所有活跃的 HeadlessWebview 和 WebviewController 实例
  - 最后一个实例 dispose 时自动调用 disposeEnvironment() 重置环境
  - 带 debugPrint 日志，可追踪实例创建/销毁和环境重置时机

  修改 initializeEnvironment() — 幂等化：
  - 新增 _environmentInitialized 标志位
  - 环境已初始化时静默返回，不再抛 PlatformException

  修改 disposeEnvironment() — 重置标志位：
  - 执行后将 _environmentInitialized 置为 false，允许重新初始化
  - 文档标注为内部自动管理，不应外部直接调用

  接入点：
  - HeadlessWebview.run() → register()，dispose() → unregister()
  - WebviewController.initialize() → register()，dispose() → unregister()