### PR TITLE
fix: prevent headless composition leaking onto desktop on Win10

### DIFF
--- a/windows/webview.cc
+++ b/windows/webview.cc
@@ -231,15 +231,20 @@ bool Webview::CreateSurface(
 
   webview_controller_->put_IsVisible(true);
 
-  // For headless webviews, set bounds to off-screen with reasonable size
-  // to prevent input capture while maintaining proper viewport dimensions
+  // For headless webviews, keep the WebView2 viewport at a valid on-screen
+  // rect so GPU rendering stays active (needed for mp4/m3u8 source probing)
+  // and the site-facing viewport looks normal. Then translate the composition
+  // root off-screen via IVisual::Offset so DWM never composes it onto the
+  // desktop. This avoids the Win10 artifact where negative Bounds leak a
+  // 1280x720 transparent rect onto the desktop.
   if (is_headless) {
     RECT bounds;
-    bounds.left = -32000;
-    bounds.top = -32000;
-    bounds.right = -32000 + 1280;
-    bounds.bottom = -32000 + 720;
+    bounds.left = 0;
+    bounds.top = 0;
+    bounds.right = 1280;
+    bounds.bottom = 720;
     webview_controller_->put_Bounds(bounds);
+    surface_->put_Offset({-32000.0f, -32000.0f, 0.0f});
   }
 
   return true;


### PR DESCRIPTION
此前，为避免在无头 WebView 上发生输入捕获，边界被移至屏幕外（-32000, 1280x720）。但在 Windows 10 及某些 Win11 配置下，DWM 仍会将该表面以折返坐标合成到桌面上，从而产生一个 1280x720 的透明矩形区域，该区域会捕获鼠标点击（Kazumi issue #1883）。

将 webview_controller_Bounds 保持在屏幕内的矩形范围内，以确保 GPU 渲染保持活跃（这是 mp4/m3u8 源文件探测所必需的），并且面向网站的视口保持正常。相反，通过 IVisual::Offset 平移合成根节点，这样无论 Bounds 坐标如何处理，DWM 都不会将其合成到桌面上。